### PR TITLE
Remove line_length rule

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,4 +1,5 @@
 disabled_rules:
+  - line_length
 included:
 excluded:
   - Carthage


### PR DESCRIPTION
The actual length isn't configurable (it's hardcoded into `SwiftLint`), and 100 is too short. Turning it off will at least reduce the noise on PRs.

ping @thoughtbot/ios