### PR TITLE
Ensure excluded files are not being linted

### DIFF
--- a/lib/jobs/swift_review_job.rb
+++ b/lib/jobs/swift_review_job.rb
@@ -10,18 +10,18 @@ require "swift_lint/runner"
 class SwiftReviewJob
   @queue = :swift_review
 
+  # This job receives the following arguments
+  # - filename
+  # - content
+  # - config
+  # - pull_request_number (pass-through)
+  # - commit_sha (pass-through)
+  # - patch (pass-through)
   def self.perform(attributes)
-    # filename
-    # commit_sha
-    # pull_request_number (pass-through)
-    # patch (pass-through)
-    # content
-    # config
-
     config = config_for(attributes: attributes)
     file = file_for(attributes: attributes)
     violations = violations_for(file: file, config: config)
-    puts "Found #{violations.size} violation(s) for #{file.name}"
+    puts "Found #{violations.size} violation(s) for #{file.path}"
 
     completed_file_review(
       file: file,
@@ -33,7 +33,7 @@ class SwiftReviewJob
   def self.completed_file_review(file:, attributes:, violations:)
     Resque.enqueue(
       CompletedFileReviewJob,
-      filename: file.name,
+      filename: file.path,
       commit_sha: attributes.fetch("commit_sha"),
       pull_request_number: attributes.fetch("pull_request_number"),
       patch: attributes.fetch("patch"),

--- a/lib/swift_lint/file.rb
+++ b/lib/swift_lint/file.rb
@@ -2,7 +2,7 @@ require "tmpdir"
 
 module SwiftLint
   class File
-    attr_reader :content
+    attr_reader :path, :content
 
     def initialize(path, content)
       @path = path
@@ -16,18 +16,13 @@ module SwiftLint
       end
     end
 
-    def name
-      ::File.basename(path)
-    end
-
     def write_to_dir(dir)
-      ::File.open(::File.join(dir, name), "w") do |file|
+      temp_file_path = ::File.join(dir, path)
+      FileUtils.mkdir_p(::File.dirname(temp_file_path))
+
+      ::File.open(temp_file_path, "w") do |file|
         file.write(content)
       end
     end
-
-    private
-
-    attr_reader :path
   end
 end

--- a/spec/lib/swift_lint/file_spec.rb
+++ b/spec/lib/swift_lint/file_spec.rb
@@ -13,14 +13,6 @@ describe SwiftLint::File do
     end
   end
 
-  describe "#name" do
-    it "returns basename from path" do
-      file = SwiftLint::File.new("/some/path/file.swift", "")
-
-      expect(file.name).to eq("file.swift")
-    end
-  end
-
   describe "#write_to_dir" do
     it "writes files in the given directory" do
       Dir.mktmpdir do |dir|

--- a/spec/lib/swift_lint/runner_spec.rb
+++ b/spec/lib/swift_lint/runner_spec.rb
@@ -20,7 +20,7 @@ describe SwiftLint::Runner do
     if RUBY_PLATFORM =~ /darwin/
       it "returns all violations" do
         config = ConfigOptions.new("")
-        file = SwiftLint::File.new("file.swift", swift_file_content)
+        file = SwiftLint::File.new("Foo/bar.swift", swift_file_content)
         runner = SwiftLint::Runner.new(config)
 
         violations = runner.violations_for(file)
@@ -28,15 +28,15 @@ describe SwiftLint::Runner do
         expect(violations.size).to eq(6)
       end
 
-      describe "file with major violations" do
-        it "returns all violations" do
-          config = ConfigOptions.new("")
-          file = SwiftLint::File.new("file.swift", swift_major_file_content)
+      context "when directory is excluded" do
+        it "returns no violations" do
+          config = ConfigOptions.new("excluded:\n  - Foo")
+          file = SwiftLint::File.new("Foo/bar.swift", swift_file_content)
           runner = SwiftLint::Runner.new(config)
 
           violations = runner.violations_for(file)
 
-          expect(violations.size).to eq(1)
+          expect(violations.size).to eq(0)
         end
       end
     end
@@ -54,16 +54,6 @@ public func <*> <T, U>(f: (T -> U)?, a: T?) -> U? {
     print('using backticks `')
     let colonOnWrongSide :Int = 0 as! Int
     return a.apply(f)
-}
-    SWIFT
-  end
-
-  def swift_major_file_content
-    <<-SWIFT
-class ShortVariableName {
-  func tooShort(a: Int) {
-    print("I am too short \(a)")
-  }
 }
     SWIFT
   end


### PR DESCRIPTION
Files are now created in their respective directories before being
linted, and thus excluded directories/files will be honored.